### PR TITLE
fix: 修复check-code-style在基提交不存在时的错误

### DIFF
--- a/.github/workflows/check-code-sytle.yml
+++ b/.github/workflows/check-code-sytle.yml
@@ -47,6 +47,12 @@ jobs:
           else
             base=${PR_BASE}
           fi
-          git diff --name-only --diff-filter=d "${base}" | {
-            grep -E '\.(c|cpp|h|hpp)$' || [[ $? -le 1 ]]
-          } | tr '\n' '\0' | xargs -0 clang-format --dry-run -Werror
+          if git rev-parse --quiet --verify "${base}" >/dev/null; then
+            git diff --name-only --diff-filter=d "${base}" | {
+              grep -E '\.(c|cpp|h|hpp)$' || [[ $? -le 1 ]]
+            } | tr '\n' '\0' | xargs -0 clang-format --dry-run -Werror
+          else
+            git ls-tree -r --name-only HEAD | {
+              grep -E '\.(c|cpp|h|hpp)$' || [[ $? -le 1 ]]
+            } | tr '\n' '\0' | xargs -0 clang-format --dry-run -Werror
+          fi


### PR DESCRIPTION
基提交不存在时，例如当前提交为初始提交，则直接检查当前所有被追踪的文件